### PR TITLE
docs: fix trivy badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Panoptes API
 
-[![Trivy Scan](https://github.com/panoptescloud/orca/actions/workflows/nightly_scan.yaml/badge.svg?label=Blah)](https://github.com/panoptescloud/orca/actions/workflows/nightly_scan.yaml)
+[![Trivy Scan](https://github.com/panoptescloud/api/actions/workflows/nightly_scan.yaml/badge.svg?label=Blah)](https://github.com/panoptescloud/api/actions/workflows/nightly_scan.yaml)
 
 Documentation is found on Github pages: [https://panoptescloud.github.io/api/](https://panoptescloud.github.io/api/)
 


### PR DESCRIPTION
Copy paste issue from another readme, was pointing to wrong repository.